### PR TITLE
DB comment size has been increased since MySQL-5.5.3 so increase it

### DIFF
--- a/src/org/insightech/er/db/impl/mysql/MySQLDDLCreator.java
+++ b/src/org/insightech/er/db/impl/mysql/MySQLDDLCreator.java
@@ -337,15 +337,17 @@ public class MySQLDDLCreator extends DDLCreator {
 
 	@Override
 	public String getDropDDL(ERDiagram diagram) {
+		String dropDDL = super.getDropDDL(diagram);
+		if (dropDDL.isEmpty()) {
+			return dropDDL;
+		}
 		StringBuilder ddl = new StringBuilder();
 		ddl.append("SET SESSION FOREIGN_KEY_CHECKS=0");
 		if (this.semicolon) {
 			ddl.append(";");
 		}
 		ddl.append("\r\n");
-
-		ddl.append(super.getDropDDL(diagram));
-
+		ddl.append(dropDDL);
 		return ddl.toString();
 	}
 


### PR DESCRIPTION
Increase the DB comment size of MySQL in DDL creation process.

 DB comment size has been increased since MySQL-5.5.3 like this:
   table  : 60 -> 2048
   column : 255 -> 1024
 *http://dev.mysql.com/doc/refman/5.5/en/create-table.html

 actual test result in Server version: 5.5.19-log MySQL Community Server (GPL)
   Caused by: java.sql.SQLException: Comment for table 'member' is too long (max = 2048)
   Caused by: java.sql.SQLException: Comment for field 'REGISTER_DATETIME' is too long (max = 1024)

 ERMaster-b is forked product
 so no problem basically for new version
