### PR TITLE
Remove FK check off of MySQL when all drop DDLs are off

### DIFF
--- a/src/org/insightech/er/db/impl/mysql/MySQLDDLCreator.java
+++ b/src/org/insightech/er/db/impl/mysql/MySQLDDLCreator.java
@@ -337,15 +337,17 @@ public class MySQLDDLCreator extends DDLCreator {
 
 	@Override
 	public String getDropDDL(ERDiagram diagram) {
+		String dropDDL = super.getDropDDL(diagram);
+		if (dropDDL.isEmpty()) {
+			return dropDDL;
+		}
 		StringBuilder ddl = new StringBuilder();
 		ddl.append("SET SESSION FOREIGN_KEY_CHECKS=0");
 		if (this.semicolon) {
 			ddl.append(";");
 		}
 		ddl.append("\r\n");
-
-		ddl.append(super.getDropDDL(diagram));
-
+		ddl.append(dropDDL);
 		return ddl.toString();
 	}
 


### PR DESCRIPTION
When DDL export for MySQL, statement of FK check off is valid even if all drop DDL off.
So remove it when all drop DDLs are off.
(However, basically the check might be unnecessary...)
