### PR TITLE
"CREATE TABLE" syntax error with "BINARY" attribute for mysql column

### DIFF
--- a/META-INF/MANIFEST.MF
+++ b/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: ERMaster
 Bundle-SymbolicName: org.insightech.er; singleton:=true
-Bundle-Version: 1.5.0.2
+Bundle-Version: 1.5.0.3
 Bundle-Activator: org.insightech.er.Activator
 Bundle-Localization: plugin
 Require-Bundle: org.eclipse.ui,

--- a/src/org/insightech/er/db/impl/mysql/MySQLDDLCreator.java
+++ b/src/org/insightech/er/db/impl/mysql/MySQLDDLCreator.java
@@ -129,8 +129,20 @@ public class MySQLDDLCreator extends DDLCreator {
 			}
 		}
 
+		String constraint = Format.null2blank(normalColumn.getConstraint());
+		if ("BINARY".equalsIgnoreCase(constraint)) {
+            ddl.append(" ");
+            ddl.append(constraint);
+            constraint = "";
+        }
+
 		if (normalColumn.isNotNull()) {
 			ddl.append(" NOT NULL");
+		}
+
+		if (!"".equals(constraint)) {
+			ddl.append(" ");
+			ddl.append(constraint);
 		}
 
 		if (normalColumn.isUniqueKey()) {
@@ -139,12 +151,6 @@ public class MySQLDDLCreator extends DDLCreator {
 				ddl.append(normalColumn.getUniqueKeyName());
 			}
 			ddl.append(" UNIQUE");
-		}
-
-		String constraint = Format.null2blank(normalColumn.getConstraint());
-		if (!"".equals(constraint)) {
-			ddl.append(" ");
-			ddl.append(constraint);
 		}
 
 		if (normalColumn.isAutoIncrement()) {


### PR DESCRIPTION
mysqlのカラムにbinary属性をつけたときに、
ddlとして出力されるcreate table文の該当カラムの文法がおかしい点の修正。
version 1.5.0.3 としてビルド済み。
